### PR TITLE
Agent connection message

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,16 +57,16 @@ deps: $(BUF)
 
 .PHONY: local
 local: $(BUF)
-	buf check lint --input ./proto
-	buf check breaking --against-input '.git#branch=master'
+	buf check lint ./proto
+	buf check breaking --against '.git#branch=master'
 
 # https is what we run when testing in most CI providers.
 # This does breaking change detection against our  git repository.
 
 .PHONY: CI
 CI: $(BUF)
-	buf check lint --input ./proto
-	buf check breaking --against-input ".git#branch=master"
+	buf check lint ./proto
+	buf check breaking --against ".git#branch=master"
 
 .PHONY: clean
 clean:

--- a/proto/agent/v1/connection.proto
+++ b/proto/agent/v1/connection.proto
@@ -1,0 +1,43 @@
+syntax = "proto3";
+option go_package = "agent/v1;agent";
+
+package agent.v1;
+
+import "google/protobuf/timestamp.proto";
+import "google/protobuf/duration.proto";
+
+
+message UpdateAgentConnection {
+    string claim_id = 1;
+    bool reachable = 2;
+
+    int64 session_id = 3;
+
+    ConnectionUpdateSource update_source = 4;
+
+    // mqtt_broker_addr shard to use for reaching the agent
+    // cloud injects this information
+    string mqtt_broker_addr = 5;
+
+    google.protobuf.Timestamp updated_at = 6;
+
+    // > 15 optional fields:
+    // How long the system was running until connection (only applicable when reachable=true)
+    google.protobuf.Timestamp system_uptime = 15;
+
+    // How long the netdata agent was running until connection (only applicable when reachable=true)
+    google.protobuf.Timestamp agent_uptime = 16;
+}
+
+
+// ConnectionUpdateSource is to determine whether the connection update was issued 
+enum ConnectionUpdateSource {
+    // CONNECTION_UPDATE_SOURCE_UNSPECIFIED acts as default value for protobuf and is never specified
+    CONNECTION_UPDATE_SOURCE_UNSPECIFIED = 0;
+    // CONNECTION_UPDATE_SOURCE_AGENT A direct message from an agent
+    CONNECTION_UPDATE_SOURCE_AGENT = 1;
+    // CONNECTION_UPDATE_SOURCE_LWT message delivered as the Last Will and Testiment  from MQTT broker if an agent connection with the broker is lost 
+    CONNECTION_UPDATE_SOURCE_LWT = 2;
+    // CONNECTION_UPDATE_SOURCE_HEURISTIC A cloud generated message to sanitize incorrect internal state
+    CONNECTION_UPDATE_SOURCE_HEURISTIC = 3;
+}

--- a/proto/agent/v1/connection.proto
+++ b/proto/agent/v1/connection.proto
@@ -23,10 +23,10 @@ message UpdateAgentConnection {
 
     // > 15 optional fields:
     // How long the system was running until connection (only applicable when reachable=true)
-    google.protobuf.Timestamp system_uptime = 15;
+    google.protobuf.Duration system_uptime = 15;
 
     // How long the netdata agent was running until connection (only applicable when reachable=true)
-    google.protobuf.Timestamp agent_uptime = 16;
+    google.protobuf.Duration agent_uptime = 16;
 }
 
 


### PR DESCRIPTION
Introduce new `UpdateAgentConnection`. The first and the last message (part of the last will and testament) sent from the agent to inform the cloud about agent reachability as defined in the NG-Architecture.

This message schema will be shared between cloud and netdata agent, thus is added in `aclk-schema` instead of `cloud-schema`