### PR TITLE
Add hops in nodeinstance creation message

### DIFF
--- a/proto/nodeinstance/create/v1/creation.proto
+++ b/proto/nodeinstance/create/v1/creation.proto
@@ -19,6 +19,10 @@ message CreateNodeInstance {
     // mqtt_broker_addr shard to use for reaching the agent
     // cloud injects this information.
     string mqtt_broker_addr = 5;
+
+    // hops is the number of streaming hops between collection of node data
+    //   and the claimed agent. Zero if no streaming is involved.
+    int32 hops = 6;
 }
 
 message CreateNodeInstanceResult {


### PR DESCRIPTION
`hops` is the number of streaming hops between the collection of node data and the claimed agent. Zero if no streaming is involved.

We need hops in the creation message/command so we know if the newly create node should join predefined rooms IDs, which in only applicable if `hops=0` (not a child)