### PR TITLE
Add UpdateChartConfigs command

### DIFF
--- a/proto/chart/v1/config.proto
+++ b/proto/chart/v1/config.proto
@@ -1,0 +1,13 @@
+syntax = "proto3";
+option go_package = "chart/config/v1;charts";
+
+package chart.v1;
+
+// ChartConfigListUpdated command contains the list of missing chart configs from the cloud to agent
+message UpdateChartConfigs {
+  // claim_id, node_id pair is used to identify the Node Instance
+  string claim_id = 1;
+  string node_id = 2;
+  // list of config hashes missing from cloud and requested from the agent
+  repeated string config_hashes = 3;
+}

--- a/proto/chart/v1/config.proto
+++ b/proto/chart/v1/config.proto
@@ -3,7 +3,7 @@ option go_package = "chart/config/v1;config";
 
 package config.v1;
 
-// ChartConfigListUpdated command contains the list of missing chart configs from the cloud to agent
+// UpdateChartConfigs command contains the list of missing chart configs from the cloud to agent
 message UpdateChartConfigs {
   // claim_id, node_id pair is used to identify the Node Instance
   string claim_id = 1;

--- a/proto/chart/v1/config.proto
+++ b/proto/chart/v1/config.proto
@@ -1,7 +1,7 @@
 syntax = "proto3";
-option go_package = "chart/config/v1;charts";
+option go_package = "chart/config/v1;config";
 
-package chart.v1;
+package config.v1;
 
 // ChartConfigListUpdated command contains the list of missing chart configs from the cloud to agent
 message UpdateChartConfigs {


### PR DESCRIPTION
This command serves to enable the cloud to request missing chartConfigs from an agent.

More info about the overall functionality can be found here: https://github.com/netdata/cloud-charts-service/pull/8 