### PR TITLE
drop id(1), name(2) from ChartConfigUpdated proto def

### DIFF
--- a/proto/chart/v1/config.proto
+++ b/proto/chart/v1/config.proto
@@ -18,18 +18,16 @@ message ChartConfigsUpdated {
 }
 
 message ChartConfigUpdated {
-//  string id = 1;
-//  string name = 2;
-  string type = 3;
-  string family = 4;
-  string context = 5;
-  string title = 6;
-  uint64 priority = 7;
-  string plugin = 8;
-  string module = 9;
-  ChartType chart_type = 10;
-  string units = 11;
-  string config_hash = 12;
+  string type = 1;
+  string family = 2;
+  string context = 3;
+  string title = 4;
+  uint64 priority = 5;
+  string plugin = 6;
+  string module = 7;
+  ChartType chart_type = 8;
+  string units = 9;
+  string config_hash = 10;
 }
 
 enum ChartType {

--- a/proto/chart/v1/config.proto
+++ b/proto/chart/v1/config.proto
@@ -18,8 +18,8 @@ message ChartConfigsUpdated {
 }
 
 message ChartConfigUpdated {
-  string id = 1;
-  string name = 2;
+//  string id = 1;
+//  string name = 2;
   string type = 3;
   string family = 4;
   string context = 5;


### PR DESCRIPTION
~~I intentionally commented out the fields instead of removing them, as a reminder not to reuse the field numbers (1, 2) by accident in the future.~~

Re initialized the field numbering in `ChartConfigUpdated` proto definition and dropped the `id` and `name` fields.

Thanks @MrZammler for pointing this out! 👍🏼 

