### PR TITLE
Rename services field to collectors

### DIFF
--- a/proto/nodeinstance/info/v1/info.proto
+++ b/proto/nodeinstance/info/v1/info.proto
@@ -102,7 +102,8 @@ message NodeInfo {
 
   string custom_info = 17;
 
-  repeated string services = 18;
+  // [Obsolete] repeated string services = 18;
+  reserved 18;
 
   string machine_guid = 19;
 
@@ -112,6 +113,8 @@ message NodeInfo {
   map<string, string> host_labels = 21;
 
   MachineLearningInfo ml_info = 22;
+  
+  repeated string collectors = 23;
 }
 
 message MachineLearningInfo {


### PR DESCRIPTION
The `collectors` field will contain a list of collectors from an agent. The `services` field was supposed to do that, but the name `collectors` is more fitting and won't conflict with other BE fields.

From the agent side the `services` field was always set to NULL and never had anything transmitted over it using the new architecture.