### PR TITLE
Add chart's context to alert events

### DIFF
--- a/proto/alarm/v1/stream.proto
+++ b/proto/alarm/v1/stream.proto
@@ -86,6 +86,9 @@ message AlarmLogEntry {
 
     // Rendered_info 
     string rendered_info = 28;
+    
+    // The chart's context field
+    string chart_context = 29;
 }
 
 enum AlarmStatus {


### PR DESCRIPTION
Adds a new field to transmit the chart's context with the alert events.