### PR TITLE
Add an alert event hash

### DIFF
--- a/proto/alarm/v1/stream.proto
+++ b/proto/alarm/v1/stream.proto
@@ -103,10 +103,10 @@ message AlarmLogEntry {
     string chart_context = 29;
     
     // Counter of alert transitions for this alert chain
-    uint64 alert_event_id = 30;
+    uint64 event_id = 30;
     
     // A unique uuid for this alert event
-    string alert_event_hash = 31;
+    string transition_id = 31;
 }
 
 enum AlarmStatus {

--- a/proto/alarm/v1/stream.proto
+++ b/proto/alarm/v1/stream.proto
@@ -101,6 +101,12 @@ message AlarmLogEntry {
 
     // The chart's context field
     string chart_context = 29;
+    
+    // Counter of alert transitions for this alert chain
+    uint64 alert_event_id = 30;
+    
+    // A unique uuid for this alert event
+    string alert_event_hash = 31;
 }
 
 enum AlarmStatus {


### PR DESCRIPTION
Adds an entry for an alert event hash. This will be a uuid, unique for each alert event.

Also added the alert_event_id as currently produced by the agent.