### PR TITLE
Add chart labels key to config.proto

### DIFF
--- a/proto/alarm/v1/config.proto
+++ b/proto/alarm/v1/config.proto
@@ -55,4 +55,6 @@ message AlarmConfiguration{
     string p_db_lookup_method = 31;
     string p_db_lookup_options = 32;
     int32 p_update_every = 33;
+
+    string chart_labels = 34;
 }


### PR DESCRIPTION
`chart_labels` key was added to alert configurations a bit ago, need to transmit it to the cloud.