### PR TITLE
Update alerts with summary field

### DIFF
--- a/proto/alarm/v1/config.proto
+++ b/proto/alarm/v1/config.proto
@@ -57,4 +57,5 @@ message AlarmConfiguration{
     int32 p_update_every = 33;
 
     string chart_labels = 34;
+    string summary = 35;
 }

--- a/proto/alarm/v1/stream.proto
+++ b/proto/alarm/v1/stream.proto
@@ -111,6 +111,9 @@ message AlarmLogEntry {
 
     // The chart's name field
     string chart_name = 32;
+
+    // The rendered summary
+    string summary = 33;
 }
 
 enum AlarmStatus {


### PR DESCRIPTION
Adds the `summary` field to both stream and config proto messages for alerts.