### PR TITLE
Remove unused import in proto/agent/v1/cmds.proto

### DIFF
--- a/proto/agent/v1/cmds.proto
+++ b/proto/agent/v1/cmds.proto
@@ -4,7 +4,7 @@ option go_package = "agent/v1;agent";
 package agent.v1;
 
 import "google/protobuf/timestamp.proto";
-import "proto/aclk/v1/lib.proto";
+// import "proto/aclk/v1/lib.proto";
 
 message CancelPendingRequest {
     // must match the ID sent with the request originally made


### PR DESCRIPTION
Per the protobuf compiler output, this import is unused in this file. This results in a warning being issued whenever it’s compiled. Comment it out for now to resolve that warning.

This is part of an ongoing project I’m working on to eliminate warnings from our build output as much as possible (and thus make it easier to find build errors in build output in CI).